### PR TITLE
Refactor awssts.sh to split logic and function

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,30 @@ Set of bash scripts to generate and manage AWS STS tokens.
 
 Use them to assume roles with MFA, into different accounts, etc.
 
+Quick start
+-----------
+
+To start using this repo:
+
+ 1. Fork this repo.
+ 2. edit `awssts.sh` to change it to your own config.
+ 3. add base AWS credentials in pass, with this format:
+    ```
+export AWS_USER_NAME="user@company.com";
+export AWS_ACCOUNT_NAME="user+admin@user";
+export AWS_ACCESS_KEY_ID="...";
+export AWS_SECRET_ACCESS_KEY="...";
+export AWS_SESSION_TOKEN=
+```
+ 4. Source the `awssts.sh` in your `.profile`: `source ~/workspace/aws_key_management/awssts.sh`
+
+Now you can simply switch credentials like this:
+
+```
+awssts role:admin@keytwine-root
+awssts role:dev@keytwine-sandbox
+```
+
 `generate-sts-token.sh`
 -----------------------
 
@@ -43,8 +67,8 @@ AWS_CACHE_GPG_ID=2EA619ED \
 	admin@keytwine -r admin -m
 ```
 
-Putting all together
--------------------
+Putting all together: awssts.sh
+-------------------------------
 
 With these two scripts, and the [password-store](https://www.passwordstore.org/)
 it is easy to create a helper to load the credentials and assume roles:
@@ -56,4 +80,8 @@ AWS_CACHE_GPG_ID=2EA619ED
 		admin@keytwine -r admin -m
 ```
 
-See the `awssts.sh` for a example of an alias for `.bashrc`.
+Following this approach, there is an example script `awssts.sh` which
+can be sourced to provide the function `awssts` which would change the
+credentials of the current shell.
+
+Check the Quick Start guide above.

--- a/awssts.sh
+++ b/awssts.sh
@@ -1,34 +1,69 @@
+#!/bin/bash
 _awssts_dir="$(command cd "$(dirname "${BASH_SOURCE}")"; pwd)"
+_awssts_script="${_awssts_dir}/${BASH_SOURCE##*/}"
 awssts() {
-  profile="$1"; shift
+  aws_account_name="$1"; shift
 
   # if an argument is passed, execute it
   if [ "$1" ]; then
-    ( awssts "${profile}"; $@ );  return $?
+    ( set -e; awssts "${aws_account_name}"; $@ ); return $?
   fi
 
-  local _aws_cache_gpg_id=2EA619ED
-  case "$profile" in
-    admin@keytwine-root)
-      eval $(pass keytwine/aws/hector.rivas+aws.admin_credentials.sh)
-      eval $(
-        AWS_CACHE_GPG_ID="${_aws_cache_gpg_id}" \
-        ${_awssts_dir}/cached-sts-token.sh \
-          admin@keytwine-root -r admin -m
-      )
-      ;;
-    dev@keytwine-root)
-      eval $(pass keytwine/aws/hector.rivas+aws.dev_credentials.sh)
-      eval $(
-        AWS_CACHE_GPG_ID="${_aws_cache_gpg_id}" \
-        ${_awssts_dir}/cached-sts-token.sh \
-          dev@keytwine-root -r dev -m
-      )
-      ;;
-    *)
-      echo "awssts <aws_profile>"
-      return 1
-      ;;
-  esac
+  eval $(${_awssts_script} "${aws_account_name}")
 }
 
+# Check if the script is being sourced or not
+# More info https://stackoverflow.com/a/2687092/395686
+if [ "$BASH_SOURCE" != "$0" ]; then
+  # The file is being source, stop processing
+  return 0
+fi
+
+_aws_cache_gpg_id=2EA619ED
+
+aws_account_name="$1"; shift
+case "$aws_account_name" in
+  user:hector.rivas+admin@keytwine)
+    pass keytwine/aws/hector.rivas+aws.admin_credentials.sh
+    ;;
+  user:hector.rivas+dev@keytwine)
+    pass keytwine/aws/hector.rivas+aws.dev_credentials.sh
+    ;;
+  role:admin@keytwine-root)
+    ROOT_AWS_CREDENTIALS_COMMAND="${_awssts_script} user:hector.rivas+admin@keytwine" \
+    AWS_CACHE_GPG_ID="${_aws_cache_gpg_id}" \
+      ${_awssts_dir}/cached-sts-token.sh \
+      ${aws_account_name} -r admin -m
+    ;;
+  role:dev@keytwine-root)
+    ROOT_AWS_CREDENTIALS_COMMAND="${_awssts_script} user:hector.rivas+dev@keytwine" \
+    AWS_CACHE_GPG_ID="${_aws_cache_gpg_id}" \
+      ${_awssts_dir}/cached-sts-token.sh \
+      ${aws_account_name} -r dev -m
+    ;;
+  role:admin@keytwine-sandbox)
+    account_id="$(pass keytwine/aws/sandbox/account_id)"
+    ROOT_AWS_CREDENTIALS_COMMAND="${_awssts_script} user:hector.rivas+admin@keytwine" \
+    AWS_CACHE_GPG_ID="${_aws_cache_gpg_id}" \
+      ${_awssts_dir}/cached-sts-token.sh \
+      ${aws_account_name} \
+      -a "${account_id}" \
+      -r admin -m
+    ;;
+  role:dev@keytwine-sandbox)
+    account_id="$(pass keytwine/aws/sandbox/account_id)"
+    ROOT_AWS_CREDENTIALS_COMMAND="${_awssts_script} user:hector.rivas+dev@keytwine" \
+    AWS_CACHE_GPG_ID="${_aws_cache_gpg_id}" \
+      ${_awssts_dir}/cached-sts-token.sh \
+      ${aws_account_name} -a "${account_id}" -r dev -m
+    ;;
+  *)
+    (
+      echo "Usage: awssts <aws_account_name>"
+      echo
+      echo "Available accounts:"
+      sed -n "s/^ *\(user:.*\))/  awssts \1/p;s/^ *\(role:.*\))/  awssts \1/p" < "${_awssts_script}" 1>&2
+    ) 1>&2
+    exit 1
+    ;;
+esac

--- a/cached-sts-token.sh
+++ b/cached-sts-token.sh
@@ -17,7 +17,8 @@ if [ -z "${1:-}" ]; then
     exit 1
 fi
 
-STS_CACHE_ID_FILE="${STS_TOKEN_CACHE_DIR}/$1.sh.gpg"
+AWS_ACCOUNT_NAME="$1"
+STS_CACHE_ID_FILE="${STS_TOKEN_CACHE_DIR}/${AWS_ACCOUNT_NAME}.sh.gpg"
 shift
 
 decrypt_cached_file() {
@@ -42,3 +43,4 @@ if ! cached_exists_and_not_expired; then
     generate_sts_token "$@"
 fi
 decrypt_cached_file
+echo "export AWS_ACCOUNT_NAME=${AWS_ACCOUNT_NAME}"

--- a/cached-sts-token.sh
+++ b/cached-sts-token.sh
@@ -3,6 +3,9 @@
 # Variables:
 #  - AWS_CACHE_GPG_ID to change the GPG key to use
 #  - STS_TOKEN_CACHE_DIR to change where the cached tokens are stored
+#  - ROOT_AWS_CREDENTIALS_COMMAND command to run to reset to the root
+#    credentials if the cached is expired (e.g. pass to get user creds,
+#    or federated login)
 #
 set -eu -o pipefail
 
@@ -34,6 +37,9 @@ cached_exists_and_not_expired() {
 }
 
 generate_sts_token() {
+    if [ "${ROOT_AWS_CREDENTIALS_COMMAND:-}" ]; then
+        eval $(eval "${ROOT_AWS_CREDENTIALS_COMMAND}")
+    fi
     mkdir -p "${STS_TOKEN_CACHE_DIR}"
     output="$("${SCRIPT_DIR}/generate-sts-token.sh" $@)"
     echo "${output}" | gpg -a -e --batch ${AWS_CACHE_GPG_ID:+-r ${AWS_CACHE_GPG_ID}} > "${STS_CACHE_ID_FILE}"

--- a/generate-sts-token.sh
+++ b/generate-sts-token.sh
@@ -74,11 +74,11 @@ else
   aws sts assume-role \
     --role-arn "${role_arn}" \
     --role-session-name "${user_name%%[+@]*}+${role_name}@${account_id}" \
-    --serial-number "${token_arn}" \
     --duration-seconds "${duration}" \
+    ${token:+--serial-number "${token_arn}" --token-code "${token}"}  \
     --output text \
     --query '[Credentials.AccessKeyId,Credentials.SecretAccessKey,Credentials.SessionToken]' \
-    ${token:+--token-code "${token}"} | \
+    | \
       awk '{ print "export AWS_ACCESS_KEY_ID=\"" $1 "\"\n" "export AWS_SECRET_ACCESS_KEY=\"" $2 "\"\n" "export AWS_SESSION_TOKEN=\"" $3 "\"" }'
   echo "export AWS_ROLE=${role_name}"
 fi


### PR DESCRIPTION
To simplify awssts.sh, we would split the implementation in two clear
parts:

 - The function definition, which would call the script awssts.sh
  and eval the value.

 - The script with the logic and the set of configured accounts.
  This part will only be executed when the script is NOT being
  sourced. We detect if the script is being sourced by checking
  `[ "$BASH_SOURCE" != "$0" ]`. See [1] for more info.

This change gets us a step further to split the hardcoded specific config
from the logic of the function.

We also add:
- logic to print the configured accounts when no args are passed.
- fix error handling in the function.
- Add base users, retrieved directly form pass, and assume roles.
  Prefix them with user: or role:
- Pass ROOT_AWS_CREDENTIALS_COMMAND to the
  `cached-sts-token.sh` command. It actually would call `awssts.sh`
  itself to get the user:* corresponding account.
- Do not pass serial-number if no MFA is used

[1] https://stackoverflow.com/a/2687092/395686